### PR TITLE
使ConfigManager传入的classLoader不再无用

### DIFF
--- a/src/main/kotlin/com/IceCreamQAQ/Yu/di/ConfigManagerDefaultImpl.kt
+++ b/src/main/kotlin/com/IceCreamQAQ/Yu/di/ConfigManagerDefaultImpl.kt
@@ -63,8 +63,6 @@ class ConfigManagerDefaultImpl(val classloader: ClassLoader, private val logger:
 
 
     private fun loadFolder(folder: String): List<String> {
-
-        val classloader = this.javaClass.classLoader
         val dirs: Enumeration<URL> = classloader.getResources(folder)!!
 
         val configFiles = ArrayList<String>();


### PR DESCRIPTION
虽然这个改动完全没用，但希望能把传入的参数用上